### PR TITLE
Remove "click here"

### DIFF
--- a/renters.md
+++ b/renters.md
@@ -135,7 +135,7 @@ It turns out sewage systems sometimes get disoriented and backup into your apart
 
 ### And more...
 
-Click <a>here</a> for a complete list of additional coverages on offer, and to be notified when more become available.
+<a>See a complete list of additional coverages on offer</a>, and sign up for notifications when more become available.
 
 
 ## Your participation if something bad happens


### PR DESCRIPTION
See https://www.w3.org/QA/Tips/noClickHere

Using "click here" is not a good practice - Not everyone will be clicking (eg. when navigating using the keyboard, or tapping rather than clicking).