### PR TITLE
Change backup to "back up"

### DIFF
--- a/renters.md
+++ b/renters.md
@@ -131,7 +131,7 @@ We provide additional coverage against earthquakes that damage your stuff. [Add 
 
 ### Add Water Backup Package
 
-It turns out sewage systems sometimes get disoriented and backup into your apartment (yuck). We provide coverage for this unfortunate situation as well. [Add water backup coverage](# "In the real doc, this will open our Live Policy editor").
+It turns out sewage systems sometimes get disoriented and back up into your apartment (yuck). We provide coverage for this unfortunate situation as well. [Add water backup coverage](# "In the real doc, this will open our Live Policy editor").
 
 ### And more...
 


### PR DESCRIPTION
When used as a verb, it should be "back up"
This was raised in pull request Fix spelling #3. Suggestion was approved but not merged.