### PR TITLE
Would love a policy that allows me to cover my longtime live-in girlfriend without paying double for her

### DIFF
--- a/renters.md
+++ b/renters.md
@@ -19,7 +19,7 @@ Please take a few minutes to read through, and [let us know](# "In the real doc,
 
 ### Who’s covered?
 
-This policy covers **Jane Doe**. You can add more people, as long as they permanently live at 5 Crosby St.
+This policy covers **Jane Doe**. You can add more people, as long as they permanently live at 5 Crosby St. Spouses and cohabitating significant others may be added for no additional charge, but you must specifically add them by name to you policy. Roommates and housemates may be covered for an additional fee.
 
 ### When?
 


### PR DESCRIPTION
Also would like you to rework your pricing: as it stands, it is more expensive for me to add my girlfriend to my policy than for her to get her own whole separate Lemonade policy, totalling in double the coverage.