### PR TITLE
Offer non-owner car insurance

### DIFF
--- a/renters.md
+++ b/renters.md
@@ -133,7 +133,7 @@ We provide additional coverage against earthquakes that damage your stuff. [Add 
 
 It turns out sewage systems sometimes get disoriented and back up into your apartment (yuck). We provide coverage for this unfortunate situation as well. [Add water backup coverage](# "In the real doc, this will open our Live Policy editor").
 
-### Add Non Owner Car Insurance
+### Add Non-Owner Automobile Package
 
 Have a driver’s license but no car? [Add non-owner automobile coverage](# "In the real doc, this will open our Live Policy editor") and we’ll cover damage or injury caused to you, others, your vehicle, or others’ vehicle(s) if you are involved in an accident while driving a rented or borrowed car.
 

--- a/renters.md
+++ b/renters.md
@@ -133,6 +133,10 @@ We provide additional coverage against earthquakes that damage your stuff. [Add 
 
 It turns out sewage systems sometimes get disoriented and back up into your apartment (yuck). We provide coverage for this unfortunate situation as well. [Add water backup coverage](# "In the real doc, this will open our Live Policy editor").
 
+### Add Non Owner Car Insurance
+
+Have a driver’s license but no car? [Add non-owner automobile coverage](# "In the real doc, this will open our Live Policy editor") and we’ll cover damage or injury caused to you, others, your vehicle, or others’ vehicle(s) if you are involved in an accident while driving a rented or borrowed car.
+
 ### And more...
 
 <a>See a complete list of additional coverages on offer</a>, and sign up for notifications when more become available.


### PR DESCRIPTION
Many of us citydwellers can drive, but find no use for owning our own car.

This can complicate things when we help a friend move, or go on a road trip using a best bud’s car, and it makes things pricey at car rental desks. Plus there aren't that many other non-owner providers out there.

If you could offer an affordable monthly add-on rate for damage & liability coverage for those who *do not* own a car, but occasionally borrow/rent cars, I'd very much consider it. (Hoping it'd be only $5-15 additional.)