### PR TITLE
Clarify deductible frequency

### DIFF
--- a/renters.md
+++ b/renters.md
@@ -145,7 +145,7 @@ Have a driver’s license but no car? [Add non-owner automobile coverage](# "In 
 
 ### AKA your ‘deductible.’ It is now set to $500.
 
-A deductible is an amount that defines your participation in potential damage. It’s called a deductible, because it’s deducted from your claim payment.
+A deductible is an amount that defines your participation every time potential damage is claimed. It’s called a deductible, because it’s deducted from your claim payment.
 
 For example, if you have an approved claim that amounts to $7,000, we will end up paying you $6,500 (after we deduct the $500 ‘deductible’). It also means there’s no point in filing claims for anything less than the $500.
 


### PR DESCRIPTION
The original language is not clear whether it's one deductible per
policy year (like health insurances) or per claim. According to #19,
deductibles are intended to be applied per claim, so hopefully this
makes it less ambiguous.

> The deductible is intended to be applied per claim, regardless of the
> coverages involved. So if you have a contents and loss of use claim,
> the deductible applies once. If you have a loss of use only claim, one
> deductible applies.

Source: https://github.com/lemonade-hq/policy-2.0/issues/19#issuecomment-390664123